### PR TITLE
po/de.po: Fix placeholder translations

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: bombono-dvd 1.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2011-10-25 01:40+0400\n"
-"PO-Revision-Date: 2011-10-29 13:30+0100\n"
-"Last-Translator: Roland Illig <roland.illig@gmx.de>\n"
+"PO-Revision-Date: 2018-03-03 11:52+0100\n"
+"Last-Translator: Thomas Perl <m@thp.io>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
 "Language: German\n"
 "MIME-Version: 1.0\n"
@@ -215,7 +215,7 @@ msgstr "Ausgabe"
 
 #: src/mgui/mux.cpp:175
 msgid "Select elementary video"
-msgstr "Wählen Sie das grundlegende Video [XXX: Bessere Übersetzung gesucht]"
+msgstr "Elementary-Stream für Video wählen"
 
 #: src/mgui/mux.cpp:176
 msgid "Select audio"
@@ -229,7 +229,7 @@ msgstr "Video"
 
 #: src/mgui/mux.cpp:183
 msgid "MPEG2 elementary video (m2v)"
-msgstr "MPEG2 grundlegendes Video (m2v) [XXX: Bessere Übersetzung gesucht]"
+msgstr "MPEG2 Elementary-Video (m2v)"
 
 #: src/mgui/mux.cpp:188 src/mgui/project/menu-browser.cpp:372
 msgid "Audio"
@@ -241,7 +241,7 @@ msgstr "Tonspur für DVD"
 
 #: src/mgui/mux.cpp:216
 msgid "Elementary video file is not selected."
-msgstr "Es ist keine grundlegende Videodatei ausgewählt. [XXX: Bessere Übersetzung gesucht]"
+msgstr "Keine Elementary-Video-Datei ausgewählt."
 
 #: src/mgui/mux.cpp:218
 msgid "Audio file is not selected."
@@ -788,11 +788,11 @@ msgstr "Bombono DVD kann derzeit nur »DVD-fähige« Videos nutzen. Benutzen Sie
 
 #: src/mgui/project/add.cpp:251
 msgid "DVD packs"
-msgstr "DVD-Pakete [XXX: Bessere Übersetzung?]"
+msgstr "DVD-Packs"
 
 #: src/mgui/project/add.cpp:253
 msgid "NAV packets"
-msgstr "NAV-Pakete [XXX: Bessere Übersetung?]"
+msgstr "NAV-Pakete"
 
 #: src/mgui/project/add.cpp:260
 msgid "This video should be transcoded due to (errors in <span foreground=\"red\">red color</span>):"
@@ -842,7 +842,7 @@ msgstr ""
 #: src/mgui/project/add.cpp:491
 #, boost-format
 msgid "The file \"%1%\" looks like elementary stream and need to be muxed before using. Run muxing?"
-msgstr "Die Datei »%1%« sieht nach einem grundlegenden Strom [XXX: Bessere Übersetzung?] aus und muss vor der Benutzung noch gemultiplext werden. Möchten Sie das jetzt machen?"
+msgstr "Die Datei »%1%« sieht nach einem Elementary Stream (ES) aus und muss vor der Benutzung noch gemultiplext werden. Möchten Sie das jetzt machen?"
 
 #: src/mgui/project/add.cpp:558
 msgid "Also:"
@@ -943,7 +943,7 @@ msgstr "_Multiplexen"
 
 #: src/mgui/project/mconstructor.cpp:685
 msgid "Mux Elementary Streams into MPEG2"
-msgstr "Grundlegende Ströme [XXX: Bessere Übersetzung für »elementary streams«?] in MPEG2 multiplexen"
+msgstr "Elementary Streams zu MPEG2 multiplexen"
 
 #: src/mgui/project/mconstructor.cpp:687
 msgid "Pr_eferences"


### PR DESCRIPTION
Remove the placeholder translations, and use the english (technical) terms for "Elementary Streams", since it's a technical term from MPEG, and doesn't need translation: https://en.wikipedia.org/wiki/Elementary_stream

cc @rillig