### PR TITLE
Fix compilation errors having ffmpeg 2:5.1

### DIFF
--- a/src/mgui/ffviewer.cpp
+++ b/src/mgui/ffviewer.cpp
@@ -37,6 +37,7 @@
 #endif
 
 C_LINKAGE_BEGIN
+#include <libavcodec/avcodec.h>
 #include <libavutil/imgutils.h>
 C_LINKAGE_END
 
@@ -111,7 +112,7 @@ static AVStream* VideoStream(FFData& ffv)
 
 AVCodecContext* GetVideoCtx(FFData& ffv)
 {
-    return VideoStream(ffv)->codec;
+    return ffv.videoCtx;
 }
 
 static bool IsValidRational(const AVRational& r)
@@ -294,6 +295,7 @@ void CloseInfo(FFData& ffi)
 #else
         av_close_input_file(ffi.iCtx);
 #endif
+        avcodec_free_context(&ffi.videoCtx);
         ffi.iCtx = 0;
     }
 }
@@ -437,8 +439,6 @@ bool OpenInfo(FFData& ffi, const char* fname, FFDiagnosis& diag)
 {
     std::string& err_str = diag.errStr;
 
-    av_register_all();
-
     ASSERT( !ffi.IsOpened() );
     bool res = false;
 
@@ -508,14 +508,14 @@ bool OpenInfo(FFData& ffi, const char* fname, FFDiagnosis& diag)
         for( int i=0; i < (int)ic->nb_streams; i++ )
         {
             AVStream* strm = ic->streams[i];
-            AVCodecContext* avctx = strm->codec;
-            if( SetIndex(video_idx, i, avctx->codec_type == AVMEDIA_TYPE_VIDEO) )
+            AVCodecParameters* avcp = strm->codecpar;
+            if( SetIndex(video_idx, i, avcp->codec_type == AVMEDIA_TYPE_VIDEO) )
                 ;
             else
                 // для демиксера имеет значение только NONE и ALL
                 strm->discard = AVDISCARD_ALL;
 
-            SetIndex(audio_idx, i, avctx->codec_type == AVMEDIA_TYPE_AUDIO);
+            SetIndex(audio_idx, i, avcp->codec_type == AVMEDIA_TYPE_AUDIO);
         }
 
         if( video_idx == -1 )
@@ -562,23 +562,29 @@ bool OpenInfo(FFData& ffi, const char* fname, FFDiagnosis& diag)
         }
     
         // открытие кодека
-        AVCodecContext* dec = ic->streams[video_idx]->codec;
-        // для H.264 и плохих TS
-        dec->strict_std_compliance = FF_COMPLIANCE_STRICT;
+        AVCodecParameters* decp = ic->streams[video_idx]->codecpar;
     
         // Chromium зачем-то выставляет явно, но такие значения уже по умолчанию
         //dec->error_concealment = FF_EC_GUESS_MVS | FF_EC_DEBLOCK;
         //dec->error_recognition = FF_ER_CAREFUL;
     
-        std::string tag_str = CodecID2Str(dec->codec_id);
+        std::string tag_str = CodecID2Str(decp->codec_id);
         // AVCodec - это одиночка, а AVCodecContext - состояние для него
         // в соответ. потоке контейнера 
-        AVCodec* codec = avcodec_find_decoder(dec->codec_id);
+        const AVCodec* codec = avcodec_find_decoder(decp->codec_id);
         if( !codec )
         {
             err_str = BF_("No decoder found for the stream: %1%") % tag_str % bf::stop;
             return false;
         }
+        AVCodecContext *dec;
+        ffi.videoCtx = dec = avcodec_alloc_context3(codec);
+        if( avcodec_parameters_to_context(dec, decp) < 0 )
+        {
+            err_str = _("Can't copy codec parameters");
+            return false;
+        }
+        dec->strict_std_compliance = FF_COMPLIANCE_STRICT;
 
         // :TRICKY: вся полезна инфо о дорожке, включая размеры видео, реально парсится 
         // в av_find_stream_info(), а в avcodec_open() - кодек только привязывается к
@@ -824,7 +830,15 @@ static void DoVideoDecode(FFViewer& ffv, int& got_picture, AVPacket* pkt)
         pkt->data = 0;
         pkt->size = 0;
     }
-    int av_res = avcodec_decode_video2(GetVideoCtx(ffv), &picture, &got_picture, pkt);
+    int av_res = avcodec_send_packet(GetVideoCtx(ffv), pkt);
+    if( av_res >= 0 )
+    {
+      av_res = avcodec_receive_frame(GetVideoCtx(ffv), &picture);
+      if( av_res >= 0 )
+      {
+        got_picture = 1;
+      }
+    }
 #else
     const uint8_t* buf = 0;
     int buf_sz = 0;
@@ -870,7 +884,8 @@ static bool DoDecode(FFViewer& ffv)
         // в идеале длительность уже была рассчитана в предыдущем pkt->duration;
         // пока же сделаем копипаст как в ffmpeg.c - см. особенности ffmpeg (compute_pkt_fields()) 
         AVStream* st = VideoStream(ffv);
-        int ticks    = st->parser ? st->parser->repeat_pict + 1 : dec->ticks_per_frame ;
+        AVCodecParserContext *pctx = av_stream_get_parser(st);
+        int ticks    = pctx ? pctx->repeat_pict + 1 : dec->ticks_per_frame;
         next_pts    += VideoFrameLength(dec, ticks);
     }
 
@@ -1082,7 +1097,7 @@ static bool CanByteSeek(AVFormatContext* ic)
     // переход по позиции не работает для avi, mkv - см. особенности ffmpeg
     // однако для без-заголовочных демиксеров (MPEG-PS, MPEG-TS) требуется
 
-    typedef std::map<std::string, AVInputFormat*> Map;
+    typedef std::map<std::string, const AVInputFormat*> Map;
     static Map map;
     if( map.empty() )
     {

--- a/src/mgui/ffviewer.h
+++ b/src/mgui/ffviewer.h
@@ -53,6 +53,7 @@ struct FFViewer;
 //
 typedef FFViewer VideoViewer;
 
+struct AVCodecContext;
 struct FFData;
 double FrameFPS(FFData& ffv);
 double Duration(FFData& ffv);
@@ -70,6 +71,7 @@ RefPtr<Gdk::Pixbuf> GetRawFrame(double time, FFViewer& ffv);
 struct FFData: public boost::noncopyable
 {
     AVFormatContext* iCtx;
+     AVCodecContext* videoCtx;
                 int  videoIdx;
               Point  vidSz; // первоначальный размер
 

--- a/src/mgui/project/media-browser.cpp
+++ b/src/mgui/project/media-browser.cpp
@@ -240,8 +240,8 @@ RTCache& GetRTC(VideoItem vi)
         a_cnt = 0;
         for( int i=0; i < (int)ic->nb_streams; i++ )
         {
-            AVCodecContext* avctx = ic->streams[i]->codec;
-            if( avctx->codec_type == AVMEDIA_TYPE_AUDIO )
+            AVCodecParameters* avp = ic->streams[i]->codecpar;
+            if( avp->codec_type == AVMEDIA_TYPE_AUDIO )
                 a_cnt++;
         }
 


### PR DESCRIPTION
In ffmpeg 2:5.1, the AVStream has no codec field. Instead, client needs to allocate and manage an AVCodecContext instance independently. Also, the avcodec_decode_video2 is removed, requiring calling avcodec_send_packet and avcodec_receive_frame instead.

This merge request enables compilation with these scons arguments: `CPPFLAGS="-std=c++14 -DBOOST_SYSTEM_NO_DEPRECATED -DBOOST_FILESYSTEM_NO_DEPRECATED -DBOOST_FILESYSTEM_VERSION=3" USE_EXT_BOOST=1`